### PR TITLE
Added support for KDE

### DIFF
--- a/bluetooth-lock.py
+++ b/bluetooth-lock.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 
 ENV = "KDE"   # Can be 'KDE' or 'GNOME'
-DEVICEADDR = "AA:BB:CC:DD:EE:FF"  # bluetooth device address
+DEVICEADDR = "AA:BB:CC:DD:EE:FF" # bluetooth device address
 CHECKINTERVAL = 60  # device pinged at this interval (seconds) when screen is unlocked
 CHECKREPEAT = 2  # device must be unreachable this many times to lock
 mode = 'unlocked'
@@ -28,12 +28,18 @@ if __name__ == "__main__":
 
         if process.returncode == 0 and mode == 'locked':
             mode = 'unlocked'
-            subprocess.Popen(['gnome-screensaver-command', '--deactivate'], shell=False, stdout=subprocess.PIPE)
+            if ENV == "KDE":
+                subprocess.Popen(['loginctl', 'unlock-session', '1'], shell=False, stdout=subprocess.PIPE)
+            elif ENV == "GNOME":
+                subprocess.Popen(['gnome-screensaver-command', '--deactivate'], shell=False, stdout=subprocess.PIPE)
 
         if process.returncode == 1 and mode == 'unlocked':
             mode = 'locked'
-            subprocess.Popen(['gnome-screensaver-command', '--lock'], shell=False, stdout=subprocess.PIPE)
-
+            if ENV == "KDE":
+                subprocess.Popen(['loginctl', 'lock-session', '1'], shell=False, stdout=subprocess.PIPE)
+            elif ENV == "GNOME":
+                subprocess.Popen(['gnome-screensaver-command', '--lock'], shell=False, stdout=subprocess.PIPE)
+            
         if mode == 'locked':
             time.sleep(1)
         else:

--- a/bluetooth-lock.py
+++ b/bluetooth-lock.py
@@ -7,6 +7,7 @@ from optparse import OptionParser
 import subprocess
 import time
 
+ENV = "KDE"   # Can be 'KDE' or 'GNOME'
 DEVICEADDR = "AA:BB:CC:DD:EE:FF"  # bluetooth device address
 CHECKINTERVAL = 60  # device pinged at this interval (seconds) when screen is unlocked
 CHECKREPEAT = 2  # device must be unreachable this many times to lock

--- a/bluetooth-lock.py
+++ b/bluetooth-lock.py
@@ -7,7 +7,7 @@ from optparse import OptionParser
 import subprocess
 import time
 
-ENV = "KDE"   # Can be 'KDE' or 'GNOME'
+ENV = "KDE"  # Can be 'KDE' or 'GNOME'
 DEVICEADDR = "AA:BB:CC:DD:EE:FF" # bluetooth device address
 CHECKINTERVAL = 60  # device pinged at this interval (seconds) when screen is unlocked
 CHECKREPEAT = 2  # device must be unreachable this many times to lock


### PR DESCRIPTION
Added a variable for selecting KDE och Gnome support. KDE support uses the loginctl command to lock/unlock the screen. 